### PR TITLE
➖ Remove dotenv

### DIFF
--- a/.github/workflows/node.js.yaml
+++ b/.github/workflows/node.js.yaml
@@ -34,7 +34,7 @@ jobs:
       - run: pnpm run test:coverage
 
       - uses: actions/upload-artifact@v4
-        if: github.actor != 'nektos/act'
+        if: github.actor != 'nektos/act' && github.event_name != 'merge_group'
         with:
           name: coverage
           path: coverage
@@ -76,6 +76,18 @@ jobs:
           skip-empty: true
 
       - run: |
+          pnpm dlx ts-autofix --project tsconfig.json
+          git add .
+      - id: commit-ts-autofix
+        uses: qoomon/actions--create-commit@v1
+        with:
+          message: |
+            💚 ts-autofix --project tsconfig.json
+
+            [dependabot skip]
+          skip-empty: true
+
+      - run: |
           pnpm run format
           git add .
       - id: commit-format
@@ -99,5 +111,5 @@ jobs:
             [dependabot skip]
           skip-empty: true
 
-      - if: steps.commit-lockfile.outputs.commit || steps.commit-format.outputs.commit || steps.commit-lint.outputs.commit
+      - if: steps.commit-lockfile.outputs.commit || steps.commit-ts-autofix.outputs.commit || steps.commit-format.outputs.commit || steps.commit-lint.outputs.commit
         run: git push

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ import {
 } from "@natoboram/load_env"
 import type { UUID } from "node:crypto"
 
-loadEnv()
+await loadEnv()
 
 export const EXAMPLE_BOOLEAN: boolean = envBool("EXAMPLE_BOOLEAN")
 export const EXAMPLE_DATE: Date = envDate("EXAMPLE_DATE")
@@ -103,6 +103,8 @@ import {
 	secretUuid,
 } from "@natoboram/load_env"
 import type { UUID } from "node:crypto"
+
+await loadEnv()
 
 export const SECRET_BOOLEAN: boolean = await secretBool("SECRET_BOOLEAN")
 export const SECRET_DATE: Date = await secretDate("SECRET_DATE")

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"vitest": "^3.2.4"
 	},
 	"engines": {
-		"node": ">=22"
+		"node": ">=22.12"
 	},
 	"type": "module",
 	"exports": {

--- a/package.json
+++ b/package.json
@@ -43,9 +43,6 @@
 		"test:coverage": "vitest run --coverage",
 		"test:watch": "vitest"
 	},
-	"dependencies": {
-		"dotenv": "^17.2.1"
-	},
 	"devDependencies": {
 		"@eslint/js": "^9.33.0",
 		"@types/node": "^24.2.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
 		"typescript-eslint": "^8.39.0",
 		"vitest": "^3.2.4"
 	},
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      dotenv:
-        specifier: ^17.2.1
-        version: 17.2.1
     devDependencies:
       '@eslint/js':
         specifier: ^9.33.0
@@ -759,10 +755,6 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
-
-  dotenv@17.2.1:
-    resolution: {integrity: sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==}
-    engines: {node: '>=12'}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -2137,8 +2129,6 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
-
-  dotenv@17.2.1: {}
 
   eastasianwidth@0.2.0: {}
 

--- a/src/load_env.test.ts
+++ b/src/load_env.test.ts
@@ -3,23 +3,23 @@ import { envString } from "./env.ts"
 import { loadEnv } from "./load_env.ts"
 
 describe("loadEnv", () => {
-	test("cwd", ({ expect }) => {
-		loadEnv()
+	test("cwd", async ({ expect }) => {
+		await loadEnv()
 
 		const ENV_FILE = envString("ENV_FILE")
 		expect(ENV_FILE).toBe("cwd")
 	})
 
-	test("path", ({ expect }) => {
-		loadEnv({ path: "test" })
+	test("path", async ({ expect }) => {
+		await loadEnv({ path: "test" })
 
 		const ENV_FILE = envString("ENV_FILE")
 		expect(ENV_FILE).toBe("test")
 	})
 
-	test("development", ({ expect }) => {
+	test("development", async ({ expect }) => {
 		delete process.env["NODE_ENV"]
-		loadEnv()
+		await loadEnv()
 
 		const ENV_FILE = envString("ENV_FILE")
 		expect(ENV_FILE).toBe("development")

--- a/src/load_env.ts
+++ b/src/load_env.ts
@@ -1,6 +1,6 @@
 import { readFile } from "fs/promises"
-import { join } from "path"
-import { parseEnv } from "util"
+import { join } from "node:path"
+import { parseEnv } from "node:util"
 import type { LoadedEnv } from "./loaded_env.ts"
 
 export interface LoadEnvOptions {
@@ -10,6 +10,7 @@ export interface LoadEnvOptions {
 
 interface SafeParsed {
 	readonly errors: Error[]
+
 	parsed: Record<string, unknown>
 }
 
@@ -81,7 +82,7 @@ function prepend(file: string, path: string | undefined): string {
  * @example
  * const error = await readFile(path, "utf-8").catch(toError("Couldn't read a file"))
  */
-export function toError(
+function toError(
 	message: string,
 	cause?: Record<string, unknown>,
 ): (error: unknown) => Error {

--- a/src/load_env.ts
+++ b/src/load_env.ts
@@ -1,11 +1,16 @@
-import type { DotenvConfigOptions } from "dotenv"
-import { config } from "dotenv"
+import { readFile } from "fs/promises"
 import { join } from "path"
+import { parseEnv } from "util"
 import type { LoadedEnv } from "./loaded_env.ts"
 
-export interface LoadEnvOptions extends Omit<DotenvConfigOptions, "path"> {
+export interface LoadEnvOptions {
 	/** Where to find `.env` files. */
 	readonly path?: string | undefined
+}
+
+interface SafeParsed {
+	readonly errors: Error[]
+	parsed: Record<string, unknown>
 }
 
 /** Loads environment variables from the `.env` files. `NODE_ENV` has to be set
@@ -20,24 +25,44 @@ export interface LoadEnvOptions extends Omit<DotenvConfigOptions, "path"> {
  * 3. `.env.local`
  * 4. `.env`
  *
- * @param options Additional options to be passed to `dotenv.config` where
- * `path` is where to find `.env` files.
+ * @param options Additional options to use where `path` is where to find `.env`
+ * files.
  */
-export function loadEnv(options?: LoadEnvOptions): LoadedEnv {
+export async function loadEnv(options?: LoadEnvOptions): Promise<LoadedEnv> {
 	const NODE_ENV = process.env["NODE_ENV"]?.trim() || "development"
 
-	const paths = [
+	const files = [
 		`.env.${NODE_ENV}.local`,
 		`.env.${NODE_ENV}`,
 		".env.local",
 		".env",
-	].map(file => prepend(file, options?.path))
+	]
 
-	const { parsed, error } = config({ ...options, path: paths, quiet: true })
+	const paths = files.map(file => prepend(file, options?.path))
 
-	if (!parsed)
+	const promises = paths.map(path =>
+		readFile(path, "utf-8").then(parseEnv).catch(
+			toError("An unknown error occured while reading a file", {
+				NODE_ENV,
+				path,
+			}),
+		),
+	)
+
+	const contents = await Promise.all(promises)
+
+	const { parsed, errors } = contents.reduce<SafeParsed>(
+		(merged, current) => {
+			if (current instanceof Error) merged.errors.push(current)
+			else merged.parsed = Object.assign(current, merged.parsed)
+			return merged
+		},
+		{ parsed: {}, errors: [] },
+	)
+
+	if (!Object.keys(parsed).length)
 		throw new Error("Environment variables could not be loaded.", {
-			cause: error,
+			cause: errors,
 		})
 
 	const merged = Object.assign(parsed, process.env, { NODE_ENV })
@@ -47,4 +72,38 @@ export function loadEnv(options?: LoadEnvOptions): LoadedEnv {
 
 function prepend(file: string, path: string | undefined): string {
 	return path ? join(path, file) : file
+}
+
+/**
+ * Converts a non-error into an error or supplements the cause of an error
+ * without overriding the original cause.
+ *
+ * @example
+ * const error = await readFile(path, "utf-8").catch(toError("Couldn't read a file"))
+ */
+export function toError(
+	message: string,
+	cause?: Record<string, unknown>,
+): (error: unknown) => Error {
+	return (error: unknown): Error => {
+		// Non-errors are converted to errors
+		if (!(error instanceof Error))
+			return new Error(message, { cause: { ...cause, error } })
+
+		// Anonymous objects can be augmented with additional properties
+		if (error.cause?.constructor === Object) {
+			error.cause = { ...cause, ...error.cause }
+			return error
+		}
+
+		// Falsy values don't matter
+		if (!error.cause) {
+			error.cause = cause
+			return error
+		}
+
+		// If the cause is already set and has a brittle type, then let's just leave
+		// it at that.
+		return error
+	}
 }

--- a/src/load_env.ts
+++ b/src/load_env.ts
@@ -43,7 +43,7 @@ export async function loadEnv(options?: LoadEnvOptions): Promise<LoadedEnv> {
 
 	const promises = paths.map(path =>
 		readFile(path, "utf-8").then(parseEnv).catch(
-			toError("An unknown error occured while reading a file", {
+			toError("An unknown error occurred while reading a file", {
 				NODE_ENV,
 				path,
 			}),


### PR DESCRIPTION
Turns out it's not very gigachad

### 📝 Description

<!-- Why this pull request? -->

Dotenv started putting ads in logs.

<!-- Why is this the best solution? -->

`parseEnv` was added to Node.js a little while ago, so it's best to use it.

<!-- What you did -->

* Uninstall dotenv
* Use `parseEnv` instead

### 📓 References

<!-- A list of links to discussions, documentation, issues, pull requests -->

* Closes https://github.com/NatoBoram/load_env/issues/69


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - CI now runs automatic TypeScript autofixes and can commit fixes during the workflow.

- Refactor
  - Environment loader converted to async with parallel file reads; callers must await loading.
  - Improved error reporting for env loading.

- Chores
  - Removed a runtime dotenv dependency and added a minimum Node.js engine requirement (>=22.12).

- Tests
  - Env-loading tests updated to use async/await.

- Documentation
  - README examples updated to await environment loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->